### PR TITLE
fix: handle user/collection path lookup correctly

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -19,7 +19,7 @@ jobs:
         python-version: ["3.12"]
     services:
       mongodb:
-        image: mongo:3.6
+        image: mongo:4.0
         ports:
           - 27017:27017
     steps:
@@ -33,13 +33,18 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox
+    - name: Cache tox environments
+      uses: actions/cache@v4
+      with:
+        path: .tox
+        key: ${{ matrix.python-version }}-tox-${{ hashFiles('setup.py') }}
     - name: Run Linter
       run: tox -e lint -- girder_virtual_resources
     - name: Run Tests with coverage
-      run: tox -e pytest
-    - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
       env:
         GIRDER_MAX_CURSOR_TIMEOUT_MS: 60000
+      run: tox -e pytest
+    - name: Upload Coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,20 @@ jobs:
         --user
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
+    - name: install check-manifest
+      run: >-
+        python3 -m
+        pip install
+        check-manifest
+        --user
+    - name: Check the package manifest
+      run: check-manifest -vvv
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
+
 
   publish-to-pypi:
     name: >-
@@ -42,7 +51,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -63,7 +72,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -73,14 +82,6 @@ jobs:
         inputs: >-
           ./dist/*.tar.gz
           ./dist/*.whl
-    - name: Create GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: >-
-        gh release create
-        '${{ github.ref_name }}'
-        --repo '${{ github.repository }}'
-        --notes ""
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+prune girder_virtual_resources/web_client
+exclude girder_virtual_resourcest/web_client
+prune girder_virtual_resources/tests
+exclude girder_virtual_resourcest/tests
+global-prune *.yaml
+global-exclude *.yaml
+exclude codecov.yml MANIFEST.in requirements-dev.txt tox.ini
+prune codecov.yml MANIFEST.in requirements-dev.txt tox.ini

--- a/girder_virtual_resources/rest/virtual_resource.py
+++ b/girder_virtual_resources/rest/virtual_resource.py
@@ -154,6 +154,8 @@ class VirtualResource(VirtualObject):
     def lookup(self, event):
         test = event.info["params"].get("test", False)
         path = event.info["params"].get("path")
+        if len(split(path.lstrip("/"))) < 3:
+            return    # either a user or a collection, so default to core
         response = self._lookUpPath(path, self.getCurrentUser(), test)["document"]
         event.preventDefault().addResponse(response)
 

--- a/girder_virtual_resources/tests/test_basic.py
+++ b/girder_virtual_resources/tests/test_basic.py
@@ -3,12 +3,9 @@
 
 import pathlib
 
-from girder.exceptions import ValidationException
-
 import pytest
-
+from girder.exceptions import ValidationException
 from pytest_girder.assertions import assertStatus, assertStatusOk
-
 
 chunk1, chunk2 = ("hello ", "world")
 
@@ -51,3 +48,15 @@ def test_mapping_creation(server, admin, user, public_folder):
     assert "isMapping" in resp.json
     assert resp.json["fsPath"] == "/etc"
     assert resp.json["isMapping"] is True
+
+
+@pytest.mark.plugin("virtual_resources")
+def test_lookup(server, admin):
+    resp = server.request(
+        path="/resource/lookup",
+        method="GET",
+        user=admin,
+        params={"path": f"/user/{admin['login']}"},
+    )
+    assertStatusOk(resp)
+    assert resp.json["_id"] == str(admin["_id"])

--- a/plugin.cmake
+++ b/plugin.cmake
@@ -1,1 +1,0 @@
-add_standard_plugin_tests(PACKAGE "virtual_resources")

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name="girder-virtual-resources",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="2.0.0",
+    version="2.0.1",
     description="Girder Plugin exposing physical folders and files as Girder objects.",
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Solves:

```
ERROR:girder.api.rest:500 Error
Traceback (most recent call last):
  File "/home/xarth/codes/wholetale-ng/girder/girder/api/rest.py", line 658, in endpointDecorator
    val = fun(self, path, params)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xarth/codes/wholetale-ng/girder/girder/api/rest.py", line 1237, in GET
    return self.handleRoute('GET', path, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xarth/codes/wholetale-ng/girder/girder/api/rest.py", line 976, in handleRoute
    event = events.trigger('.'.join((eventPrefix, 'before')),
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xarth/codes/wholetale-ng/girder/girder/events.py", line 168, in trigger
    handler(e)
  File "/home/xarth/codes/wholetale-ng/girder-virtual-resources/girder_virtual_resources/rest/virtual_resource.py", line 161, in lookup
    response = self._lookUpPath(path, self.getCurrentUser(), test)["document"]
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xarth/codes/wholetale-ng/girder-virtual-resources/girder_virtual_resources/rest/virtual_resource.py", line 238, in _lookUpPath
    document, model = self._get_vobject(document, path, i)
                                                        ^
UnboundLocalError: cannot access local variable 'i' where it is not associated with a value
```

for lookup `/user/foo` or `/collection/foo`.