### PR TITLE
Fix release to buid js component

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,21 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.x"
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: "18"
     - name: Install pypa/build
       run: >-
         python3 -m
         pip install
         build
         --user
+    - name: Build js component in package/web_client
+      run: >-
+        cd $(find . -maxdepth 2 -mindepth 2 -type d -name web_client)
+        && npm ci
+        && npm run build
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: install check-manifest

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name="girder-virtual-resources",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="2.1.0",
+    version="2.1.0.post1",
     description="Girder Plugin exposing physical folders and files as Girder objects.",
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
This pull request updates the release workflow and package versioning for the project. The most important changes include adding steps to build the JavaScript frontend and incrementing the Python package version to indicate a post-release update.

**Release workflow improvements:**

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R16-R30): Added Node.js setup and steps to build the JavaScript component in `package/web_client` as part of the release process.

**Versioning update:**

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L12-R12): Updated the package version from `2.1.0` to `2.1.0.post1` to reflect a post-release change.