### PR TITLE
Do not initialize symlink for a new folder

### DIFF
--- a/girder_virtual_resources/web_client/main.js
+++ b/girder_virtual_resources/web_client/main.js
@@ -12,7 +12,6 @@ wrap(FolderListWidget, 'render', function (render) {
     render.call(this);
 
     this.collection.each((folder) => {
-        console.log('Folder name:', folder.cid, folder.get('name'), folder.get('isSymlink'));
         // if isSymlink change icon
         if (folder.get('isSymlink')) {
             this.$(`.g-folder-list-link[g-folder-cid="${folder.cid}"] i.icon-folder`)

--- a/girder_virtual_resources/web_client/package-lock.json
+++ b/girder_virtual_resources/web_client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@girder/girder-virtual-resources",
-    "version": "2.2.0",
+    "version": "2.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@girder/girder-virtual-resources",
-            "version": "2.2.0",
+            "version": "2.1.1",
             "license": "BSD-3",
             "dependencies": {
                 "@girder/core": "*"

--- a/girder_virtual_resources/web_client/package.json
+++ b/girder_virtual_resources/web_client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@girder/girder-virtual-resources",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "Girder plugin that maps Girder Folders to physical directories.",
     "homepage": "https://github.com/Xarthisius/girder-virtual-resources",
     "bugs": {

--- a/girder_virtual_resources/web_client/views/FolderSymlinkWidget.js
+++ b/girder_virtual_resources/web_client/views/FolderSymlinkWidget.js
@@ -13,6 +13,10 @@ var FolderSymlinkWidget = View.extend({
     render: function () {
         const currentUser = getCurrentUser();
         const isAdmin = currentUser && currentUser.get('admin');
+        if (!this.folder || !isAdmin) {
+            this.$el.empty();
+            return this;
+        }
         const isSymlink = this.folder.get('isSymlink') ? true : false;
         this.$el.html(FolderSymlinkWidgetTemplate({
             isSymlink: isSymlink,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name="girder-virtual-resources",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="2.1.0.post2",
+    version="2.1.1",
     description="Girder Plugin exposing physical folders and files as Girder objects.",
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Remove debug statement. Prevent a failure in the new folder widget.